### PR TITLE
UNG-426 Adding support to define a path to read the dispatch info

### DIFF
--- a/event-log-dispatcher/src/main/resources/application-docker.conf
+++ b/event-log-dispatcher/src/main/resources/application-docker.conf
@@ -3,6 +3,8 @@ include "application.base.conf"
 eventLog {
 
   dispatching {
+    path: ""
+    path: ${?DIS_PATH}
     file : ${DIS_FILE}
   }
 

--- a/event-log-dispatcher/src/main/resources/application.base.conf
+++ b/event-log-dispatcher/src/main/resources/application.base.conf
@@ -1,6 +1,7 @@
 eventLog {
 
   dispatching {
+    path: "event-log-dispatcher/src/main/resources"
     file : "DispatchingPaths.json"
   }
 

--- a/event-log-dispatcher/src/main/scala/com/ubirch/dispatcher/services/DispatchInfo.scala
+++ b/event-log-dispatcher/src/main/scala/com/ubirch/dispatcher/services/DispatchInfo.scala
@@ -1,40 +1,67 @@
 package com.ubirch.dispatcher.services
 
-import java.io.{ BufferedReader, IOException, InputStream, InputStreamReader }
+import java.io.{BufferedReader, FileNotFoundException, IOException, InputStream, InputStreamReader}
+import java.nio.file.{Files, Paths}
 
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import com.ubirch.dispatcher.models.Dispatch
 import com.ubirch.services.config.ConfigProvider
 import com.ubirch.util.EventLogJsonSupport
+
+import scala.collection.JavaConverters._
+
 import javax.inject._
 
 @Singleton
 class DispatchInfo @Inject() (config: Config) extends LazyLogging {
 
   lazy val info: List[Dispatch] = loadInfo.map(x => toDispatch(x)).getOrElse(Nil)
+  val filePath: String = config.getString("eventLog.dispatching.path")
   val file: String = config.getString("eventLog.dispatching.file")
+
   private var fileStream: InputStream = _
   private var bufferReader: BufferedReader = _
 
   private def loadInfo: Option[String] = {
     try {
 
-      fileStream = getClass.getResourceAsStream("/" + file)
-      bufferReader = new BufferedReader(new InputStreamReader(fileStream))
+      val data = if(filePath.nonEmpty){
 
-      val dispatch = bufferReader.lines().toArray.toList
-      val value = dispatch.map(_.toString).mkString(" ")
+        val path = Paths.get(filePath, file)
 
-      Some(value)
+        if (!path.toFile.exists()) {
+          throw new FileNotFoundException("file not found " + file)
+        } else {
+          logger.debug("Detected file {}", path.toAbsolutePath.toString)
+        }
+
+        Some(Files.readAllLines(path).asScala.toList)
+
+      } else {
+
+        logger.debug("Reading from Resources")
+
+        fileStream = getClass.getResourceAsStream("/" + file)
+        bufferReader = new BufferedReader(new InputStreamReader(fileStream))
+
+        val dispatch = bufferReader.lines().toArray.toList
+        val value = dispatch.map(_.toString)
+
+        Some(value)
+
+      }
+
+      data.map(_.mkString(" "))
 
     } catch {
       case e: IOException =>
         logger.error("Error parsing into Dispatch {}", e.getMessage)
-        None
+        throw e
+
     } finally {
-      bufferReader.close()
-      fileStream.close()
+      if(bufferReader != null) bufferReader.close()
+      if(fileStream != null) fileStream.close()
     }
   }
 
@@ -44,6 +71,16 @@ class DispatchInfo @Inject() (config: Config) extends LazyLogging {
       val compacted = EventLogJsonSupport.stringify(fromStringData.json)
       val di = fromStringData.get
       logger.debug("Dispatching Info Found: {}", compacted)
+
+      di.foreach { d =>
+        if (d.category.isEmpty && d.category.length < 3) throw new IllegalArgumentException("Name can't be empty or has less than three letters")
+        if (d.topics.isEmpty) throw new IllegalArgumentException("Topics can't be empty.")
+        d.topics.foreach { dt =>
+          if (dt.name.isEmpty && d.category.length < 3) throw new IllegalArgumentException("Name can't be empty or has less than three letters")
+        }
+      }
+      if (di.isEmpty) throw new IllegalArgumentException("No valid Dispatching was found.")
+
       di
     } catch {
       case e: Exception =>


### PR DESCRIPTION
Adding support to load dispatching info from a file that is not in the resources folder. Note that both options are supported.