### PR TITLE
upgrade JanusGraph from 0.5.2 to 0.6.2

### DIFF
--- a/event-log-kafka-lookup/pom.xml
+++ b/event-log-kafka-lookup/pom.xml
@@ -22,9 +22,9 @@
         <!-- versions -->
 
         <event-log-core.version>1.5.0</event-log-core.version>
-        <gremlinScala.version>3.4.1.4</gremlinScala.version>
-        <janusGraph.version>0.3.1</janusGraph.version>
-        <tinkerPopDriver.version>3.3.3</tinkerPopDriver.version>
+        <gremlinScala.version>3.5.1.4</gremlinScala.version>
+        <janusGraph.version>0.6.1</janusGraph.version>
+        <tinkerPopDriver.version>3.5.1</tinkerPopDriver.version>
         <tinkerPopJava.version>2.6.0</tinkerPopJava.version>
         <json4s-native.version>3.6.0</json4s-native.version>
         <json4s-jackson.version>3.6.1</json4s-jackson.version>
@@ -74,11 +74,20 @@
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
             <version>${tinkerPopDriver.version}</version>
+            <classifier>shaded</classifier>
+            <!-- The shaded JAR uses the original POM, therefore conflicts may still need resolution -->
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.tinkerpop/gremlin-core -->
         <dependency>
-            <groupId>com.tinkerpop.gremlin</groupId>
-            <artifactId>gremlin-java</artifactId>
-            <version>${tinkerPopJava.version}</version>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-core</artifactId>
+            <version>${tinkerPopDriver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>

--- a/event-log-kafka-lookup/pom.xml
+++ b/event-log-kafka-lookup/pom.xml
@@ -22,8 +22,8 @@
         <!-- versions -->
 
         <event-log-core.version>1.5.0</event-log-core.version>
-        <gremlinScala.version>3.5.1.4</gremlinScala.version>
-        <janusGraph.version>0.6.1</janusGraph.version>
+        <gremlinScala.version>3.5.3.2</gremlinScala.version>
+        <janusGraph.version>0.6.2</janusGraph.version>
         <tinkerPopDriver.version>3.5.1</tinkerPopDriver.version>
         <tinkerPopJava.version>2.6.0</tinkerPopJava.version>
         <json4s-native.version>3.6.0</json4s-native.version>

--- a/event-log-kafka-lookup/src/main/resources/application.base.conf
+++ b/event-log-kafka-lookup/src/main/resources/application.base.conf
@@ -3,14 +3,13 @@ eventLog {
   gremlin {
 
     hosts = localhost
-    port = 8282
+    port = 8182
 
     connectionPool {
       reconnectInterval = 500
       maxWaitForConnection = 6000
     }
     serializer {
-      className = org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
       config {
         ioRegistries = [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry]
       }

--- a/event-log-kafka-lookup/src/main/scala/com/ubirch/lookup/services/DefaultGremlinConnector.scala
+++ b/event-log-kafka-lookup/src/main/scala/com/ubirch/lookup/services/DefaultGremlinConnector.scala
@@ -1,8 +1,8 @@
 package com.ubirch.lookup.services
 
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
-import com.ubirch.services.lifeCycle.{ DefaultLifecycle, Lifecycle }
+import com.ubirch.services.lifeCycle.Lifecycle
 import gremlin.scala.{ ScalaGraph, TraversalSource, _ }
 
 import javax.inject._

--- a/event-log-kafka-lookup/src/main/scala/com/ubirch/lookup/services/DefaultGremlinConnector.scala
+++ b/event-log-kafka-lookup/src/main/scala/com/ubirch/lookup/services/DefaultGremlinConnector.scala
@@ -1,17 +1,19 @@
 package com.ubirch.lookup.services
 
-import com.typesafe.config.Config
+import com.typesafe.config.{ Config, ConfigFactory }
 import com.typesafe.scalalogging.LazyLogging
-import com.ubirch.services.lifeCycle.Lifecycle
+import com.ubirch.services.lifeCycle.{ DefaultLifecycle, Lifecycle }
 import gremlin.scala.{ ScalaGraph, TraversalSource, _ }
+
 import javax.inject._
-import org.apache.commons.configuration.PropertiesConfiguration
 import org.apache.tinkerpop.gremlin.driver.Cluster
 import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection
+import org.apache.tinkerpop.gremlin.driver.ser.Serializers
 import org.apache.tinkerpop.gremlin.process.traversal.Bindings
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory
 
+import java.util
 import scala.concurrent.Future
 
 trait GremlinConnectorPaths {
@@ -35,7 +37,7 @@ class DefaultGremlinConnector @Inject() (lifecycle: Lifecycle, config: Config)
   with LazyLogging
   with GremlinConnectorPaths {
 
-  lazy val cluster: Cluster = Cluster.open(buildProperties(config))
+  lazy val cluster: Cluster = buildCluster(config)
 
   implicit val graph: ScalaGraph = EmptyGraph.instance.asScala.configure(_.withRemote(DriverRemoteConnection.using(cluster)))
   val b: Bindings = Bindings.instance
@@ -44,18 +46,28 @@ class DefaultGremlinConnector @Inject() (lifecycle: Lifecycle, config: Config)
   logger.info("[property] getNioPoolSize=" + cluster.getNioPoolSize)
   logger.info("[property] getWorkerPoolSize=" + cluster.getWorkerPoolSize)
 
-  def buildProperties(config: Config): PropertiesConfiguration = {
-    val conf = new PropertiesConfiguration()
-    conf.addProperty("hosts", config.getString(HOSTS))
-    conf.addProperty("port", config.getString(PORTS))
-    conf.addProperty("serializer.className", config.getString(CLASS_NAME))
-    conf.addProperty("connectionPool.maxWaitForConnection", config.getString(MAX_WAIT_FOR_CONNECTION))
-    conf.addProperty("connectionPool.reconnectInterval", config.getString(RECONNECT_INTERVAL))
-    // no idea why the following line needs to be duplicated. Doesn't work without
-    // cf https://stackoverflow.com/questions/45673861/how-can-i-remotely-connect-to-a-janusgraph-server first answer, second comment ¯\_ツ_/¯
-    conf.addProperty("serializer.config.ioRegistries", config.getAnyRef(IO_REGISTRIES).asInstanceOf[java.util.ArrayList[String]])
-    conf.addProperty("serializer.config.ioRegistries", config.getStringList(IO_REGISTRIES))
-    conf
+  def buildCluster(config: Config): Cluster = {
+    val cluster = Cluster.build()
+    val hosts: List[String] = config.getString(HOSTS)
+      .split(",")
+      .toList
+      .map(_.trim)
+      .filter(_.nonEmpty)
+
+    cluster.addContactPoints(hosts: _*)
+      .port(config.getInt(PORTS))
+    val maxWaitForConnection = config.getInt(MAX_WAIT_FOR_CONNECTION)
+    if (maxWaitForConnection > 0) cluster.maxWaitForConnection(maxWaitForConnection)
+
+    val reconnectInterval = config.getInt(RECONNECT_INTERVAL)
+    if (reconnectInterval > 0) cluster.reconnectInterval(reconnectInterval)
+
+    val conf = new util.HashMap[String, AnyRef]()
+    conf.put("ioRegistries", config.getAnyRef(IO_REGISTRIES).asInstanceOf[java.util.ArrayList[String]])
+    val serializer = Serializers.GRAPHBINARY_V1D0.simpleInstance()
+    serializer.configure(conf, null)
+
+    cluster.serializer(serializer).create()
   }
 
   def closeConnection(): Unit = {
@@ -75,4 +87,3 @@ class DefaultTestingGremlinConnector() extends Gremlin {
   override val b: Bindings = Bindings.instance
   override val g: TraversalSource = graph.traversal
 }
-

--- a/event-log-verification-service/pom.xml
+++ b/event-log-verification-service/pom.xml
@@ -36,9 +36,9 @@
         <!-- plugins -->
 
         <!-- Lookup POM -->
-        <gremlinScala.version>3.4.4.5</gremlinScala.version>
-        <janusGraph.version>0.5.2</janusGraph.version>
-        <tinkerPopDriver.version>3.4.8</tinkerPopDriver.version>
+        <gremlinScala.version>3.5.1.4</gremlinScala.version>
+        <janusGraph.version>0.6.1</janusGraph.version>
+        <tinkerPopDriver.version>3.5.1</tinkerPopDriver.version>
         <tinkerPopJava.version>2.6.0</tinkerPopJava.version>
         <json4s-native.version>3.6.0</json4s-native.version>
         <json4s-jackson.version>3.6.1</json4s-jackson.version>
@@ -235,15 +235,31 @@
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
             <version>${tinkerPopDriver.version}</version>
+            <classifier>shaded</classifier>
+            <!-- The shaded JAR uses the original POM, therefore conflicts may still need resolution -->
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.tinkerpop/gremlin-core -->
         <dependency>
-            <groupId>com.tinkerpop.gremlin</groupId>
-            <artifactId>gremlin-java</artifactId>
-            <version>${tinkerPopJava.version}</version>
+            <groupId>org.apache.tinkerpop</groupId>
+            <artifactId>gremlin-core</artifactId>
+            <version>${tinkerPopDriver.version}</version>
         </dependency>
+
+        <!-- Janusgraph -->
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-core</artifactId>
+            <version>${janusGraph.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-driver</artifactId>
             <version>${janusGraph.version}</version>
         </dependency>
 
@@ -252,7 +268,21 @@
             <artifactId>janusgraph-cql</artifactId>
             <version>${janusGraph.version}</version>
         </dependency>
-        <!-- /Gremlin -->
+
+        <!-- Janusgraph libraries for testing -->
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-berkeleyje</artifactId>
+            <version>${janusGraph.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.janusgraph/janusgraph-inmemory -->
+        <dependency>
+            <groupId>org.janusgraph</groupId>
+            <artifactId>janusgraph-inmemory</artifactId>
+            <version>${janusGraph.version}</version>
+        </dependency>
+
         <!-- LOOKUP POM -->
 
         <!-- Core -->

--- a/event-log-verification-service/pom.xml
+++ b/event-log-verification-service/pom.xml
@@ -36,8 +36,8 @@
         <!-- plugins -->
 
         <!-- Lookup POM -->
-        <gremlinScala.version>3.5.1.4</gremlinScala.version>
-        <janusGraph.version>0.6.1</janusGraph.version>
+        <gremlinScala.version>3.5.3.2</gremlinScala.version>
+        <janusGraph.version>0.6.2</janusGraph.version>
         <tinkerPopDriver.version>3.5.1</tinkerPopDriver.version>
         <tinkerPopJava.version>2.6.0</tinkerPopJava.version>
         <json4s-native.version>3.6.0</json4s-native.version>

--- a/event-log-verification-service/src/main/resources/application-base.conf
+++ b/event-log-verification-service/src/main/resources/application-base.conf
@@ -83,7 +83,6 @@ eventLog {
       maxWaitForConnection = 6000
     }
     serializer {
-      className = org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
       config {
         ioRegistries = [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry]
       }


### PR DESCRIPTION
- upgraded janusgraph from 0.5.3 to 0.6.2 in event-log-verification-service
- upgraded janusgraph from 0.3.1 to 0.6.2 in event-log-kakfa-lookup
- checked if the `findAnchorsWithPathAsVertices` works properly in local

**Needs to be merged when JanusGraph on dev becomes v0.6.2**