### PR TITLE
FIX(ci): Use maintained base image

### DIFF
--- a/event-log-chainer/Dockerfile
+++ b/event-log-chainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION

--- a/event-log-discovery-creator/Dockerfile
+++ b/event-log-discovery-creator/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION

--- a/event-log-dispatcher/Dockerfile
+++ b/event-log-dispatcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION

--- a/event-log-encoder/Dockerfile
+++ b/event-log-encoder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION

--- a/event-log-kafka-lookup/Dockerfile
+++ b/event-log-kafka-lookup/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION

--- a/event-log-sdk/Dockerfile
+++ b/event-log-sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION

--- a/event-log-service/Dockerfile
+++ b/event-log-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION

--- a/event-log-verification-service/Dockerfile
+++ b/event-log-verification-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION


### PR DESCRIPTION
This is part of the CVE-2022-2068 fixes.
`ubirch/java` has not been updated in years.
Switching to the Amazon corretto build of Java 8.

See: OPS-577