### PR TITLE
use static query as much as possible instead of dynamic query

### DIFF
--- a/event-log-core/src/main/scala/com/ubirch/models/CustomEncodings.scala
+++ b/event-log-core/src/main/scala/com/ubirch/models/CustomEncodings.scala
@@ -23,7 +23,7 @@ trait CustomEncodingsBase {
   * @tparam T Represent the value that holds the data for the database table.
   */
 trait CustomEncodings[T] extends CustomEncodingsBase {
-  _: TablePointer[T] =>
+  _: CassandraBase =>
 
   import db._
 

--- a/event-log-core/src/main/scala/com/ubirch/models/EventLogByCatDAO.scala
+++ b/event-log-core/src/main/scala/com/ubirch/models/EventLogByCatDAO.scala
@@ -9,16 +9,14 @@ import scala.concurrent.{ ExecutionContext, Future }
 /**
   * Represents the queries linked to the EventLogRow case class and to the Events Table
   */
-trait EventLogByCatQueries extends TablePointer[EventLogRow] with CustomEncodings[EventLogRow] {
+trait EventLogByCatQueries extends CassandraBase with CustomEncodings[EventLogRow] {
 
   import db._
 
   //These represent query descriptions only
 
-  implicit val eventSchemaMeta: db.SchemaMeta[EventLogRow] = schemaMeta[EventLogRow]("events_by_cat")
-
   def byCatAndYearAndMonthAndDayQ(category: String, year: Int, month: Int, day: Int) = quote {
-    query[EventLogRow]
+    querySchema[EventLogRow]("events_by_cat")
       .filter(x => x.category == lift(category))
       .filter(x => x.year == lift(year))
       .filter(x => x.month == lift(month))
@@ -29,7 +27,7 @@ trait EventLogByCatQueries extends TablePointer[EventLogRow] with CustomEncoding
   def byCatAndTimeElemsQ(category: String, year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int, milli: Int, limit: Int) = {
 
     val basicQuote = quote {
-      query[EventLogRow]
+      querySchema[EventLogRow]("events_by_cat")
         .filter(x => x.category == lift(category))
         .filter(x => x.year == lift(year))
         .filter(x => x.month == lift(month))

--- a/event-log-core/src/main/scala/com/ubirch/models/EventLogDAO.scala
+++ b/event-log-core/src/main/scala/com/ubirch/models/EventLogDAO.scala
@@ -1,7 +1,7 @@
 package com.ubirch.models
 
 import com.ubirch.services.cluster.ConnectionService
-import io.getquill.{ CassandraAsyncContext, Delete, EntityQuery, Insert, Quoted, SnakeCase }
+import io.getquill.{ CassandraAsyncContext, SnakeCase }
 
 import javax.inject._
 import scala.concurrent.{ ExecutionContext, Future }
@@ -9,26 +9,24 @@ import scala.concurrent.{ ExecutionContext, Future }
 /**
   * Represents the queries linked to the EventLogRow case class and to the Events Table
   */
-trait EventLogQueries extends TablePointer[EventLogRow] with CustomEncodings[EventLogRow] {
+trait EventLogQueries extends CassandraBase with CustomEncodings[EventLogRow] {
 
   import db._
 
   //These represent query descriptions only
 
-  implicit val eventSchemaMeta: db.SchemaMeta[EventLogRow] = schemaMeta[EventLogRow]("events")
-
-  def selectAllQ: Quoted[EntityQuery[EventLogRow]] = quote(query[EventLogRow])
+  def selectAllQ = quote(querySchema[EventLogRow]("events"))
 
   def byIdAndCatQ(id: String, category: String) = quote {
-    query[EventLogRow].filter(x => x.id == lift(id) && x.category == lift(category)).map(x => x)
+    querySchema[EventLogRow]("events").filter(x => x.id == lift(id) && x.category == lift(category)).map(x => x)
   }
 
-  def insertQ(eventLogRow: EventLogRow): Quoted[Insert[EventLogRow]] = quote {
-    query[EventLogRow].insert(lift(eventLogRow))
+  def insertQ(eventLogRow: EventLogRow) = quote {
+    querySchema[EventLogRow]("events").insert(lift(eventLogRow))
   }
 
-  def deleteQ(eventLogRow: EventLogRow): Quoted[Delete[EventLogRow]] = quote {
-    query[EventLogRow].filter(x => x.id == lift(eventLogRow.id) && x.category == lift(eventLogRow.category)).delete
+  def deleteQ(eventLogRow: EventLogRow) = quote {
+    querySchema[EventLogRow]("events").filter(x => x.id == lift(eventLogRow.id) && x.category == lift(eventLogRow.category)).delete
   }
 
 }

--- a/event-log-core/src/main/scala/com/ubirch/models/LookupKeyDAO.scala
+++ b/event-log-core/src/main/scala/com/ubirch/models/LookupKeyDAO.scala
@@ -1,36 +1,34 @@
 package com.ubirch.models
 
 import com.ubirch.services.cluster.ConnectionService
-import io.getquill.{ CassandraAsyncContext, EntityQuery, Insert, Quoted, SnakeCase }
+import io.getquill.{ CassandraAsyncContext, SnakeCase }
 
 import javax.inject._
 import scala.concurrent.{ ExecutionContext, Future }
 
-trait LookupKeyQueries extends TablePointer[LookupKeyRow] with CustomEncodings[LookupKeyRow] {
+trait LookupKeyQueries extends CassandraBase with CustomEncodings[LookupKeyRow] {
 
   import db._
 
   //These represent query descriptions only
 
-  implicit val eventSchemaMeta: db.SchemaMeta[LookupKeyRow] = schemaMeta[LookupKeyRow]("lookups")
-
-  def selectAllQ: Quoted[EntityQuery[LookupKeyRow]] = quote(query[LookupKeyRow])
+  def selectAllQ = quote(querySchema[LookupKeyRow]("lookups"))
 
   def byValueAndNameAndCategoryQ(value: String, name: String, category: String) = quote {
-    query[LookupKeyRow]
+    querySchema[LookupKeyRow]("lookups")
       .filter(_.value == lift(value))
       .filter(_.category == lift(category))
       .filter(_.name == lift(name))
   }
 
   def byValueAndCategoryQ(value: String, category: String) = quote {
-    query[LookupKeyRow]
+    querySchema[LookupKeyRow]("lookups")
       .filter(_.value == lift(value))
       .filter(_.category == lift(category))
   }
 
-  def insertQ(lookupKeyRow: LookupKeyRow): Quoted[Insert[LookupKeyRow]] = quote {
-    query[LookupKeyRow].insert(lift(lookupKeyRow))
+  def insertQ(lookupKeyRow: LookupKeyRow) = quote {
+    querySchema[LookupKeyRow]("lookups").insert(lift(lookupKeyRow))
   }
 
 }

--- a/event-log-core/src/main/scala/com/ubirch/models/TablePointer.scala
+++ b/event-log-core/src/main/scala/com/ubirch/models/TablePointer.scala
@@ -11,17 +11,3 @@ trait CassandraBase {
   val db: CassandraContext[_] with Encoders with Decoders
 
 }
-
-/**
-  * Value that represents a pointer to a Cassandra Table.
-  * Very useful for mapping different versions for a particular table.
-  * @tparam T represents the scala value that represent the database table.
-  */
-
-trait TablePointer[T] extends CassandraBase {
-
-  import db._
-
-  implicit val eventSchemaMeta: SchemaMeta[T]
-
-}


### PR DESCRIPTION
As we saw the memory consumption keeps growing on the development environment, my assumption is that using dynamic queries is the main cause.
It might be related to the issue below.
[NormalizeCaching cache grows without bound](https://www.github.com/zio/zio-quill/issues/2484)
> JVM does not run OOM after running a lot of dynamic queries

Therefore, I want to try to use static queries as much as possible, then do a load test and see how the memory consumption goes.